### PR TITLE
Fixed problem with reloading team list

### DIFF
--- a/lua/lambdaplayers/extaddon/shared/lambdaplayers_teamsystem.lua
+++ b/lua/lambdaplayers/extaddon/shared/lambdaplayers_teamsystem.lua
@@ -88,11 +88,11 @@ local playerTeam    = CreateLambdaConvar( "lambdaplayers_teamsystem_playerteam",
 CreateLambdaConsoleCommand( "lambdaplayers_teamsystem_updateteamlist", function( ply ) 
     LambdaTeams:UpdateData()
 
-    for _, option in ipairs( _LAMBDAConVarSettings ) do
+   for _, option in ipairs( _LAMBDAConVarSettings ) do
         local name = option.name
-        if name == "Player Team" then v.options = LambdaTeams.TeamOptions end
-        if name == "Lambda Team" then v.options = LambdaTeams.TeamOptionsRandom end
-    end
+        if option.name == "Player Team" then option.options = LambdaTeams.TeamOptions end
+        if option.name == "Lambda Team" then option.options = LambdaTeams.TeamOptionsRandom end
+   end
 
     ply:ConCommand( "spawnmenu_reload" )
 end, true, "Refreshes the team list. Use this after editting teams in the team panel.", { name = "Refresh Team List", category = "Team System" } )


### PR DESCRIPTION
Quickfix for error:

```
[lambda-players-team-system-main] addons/lambda-players-team-system-main/lua/lambdaplayers/extaddon/shared/lambdaplayers_teamsystem.lua:94: attempt to index global 'v' (a nil value)
  1. unknown - addons/lambda-players-team-system-main/lua/lambdaplayers/extaddon/shared/lambdaplayers_teamsystem.lua:94
   2. unknown - lua/includes/modules/concommand.lua:54
```
